### PR TITLE
Rename app from LingoLens to LecteurAide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LingoLens Reader
+# LecteurAide Reader
 
 Production-ready scaffold for bilingual reading app using FastAPI + Next.js.
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,1 +1,1 @@
-# LingoLens Reader backend package
+# LecteurAide Reader backend package

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from .api import books, progress, admin
 
 def create_app() -> FastAPI:
     settings = get_settings()
-    app = FastAPI(title="LingoLens Reader")
+    app = FastAPI(title="LecteurAide Reader")
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["http://localhost:3000"],

--- a/backend/app/services/pipeline/ingest.py
+++ b/backend/app/services/pipeline/ingest.py
@@ -2,7 +2,7 @@ from celery import Celery
 from ..config import get_settings
 
 settings = get_settings()
-celery_app = Celery("lingolens", broker=settings.redis_url)
+celery_app = Celery("lecteuraide", broker=settings.redis_url)
 
 
 @celery_app.task

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lingolens-reader",
+  "name": "lecteuraide-reader",
   "version": "0.1.0",
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Rename project branding from LingoLens to LecteurAide across backend, frontend and docs
- Update Celery worker name to match new branding

## Testing
- `cd backend && pytest`
- `cd frontend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c7862d80b0832a8816315a1d00f7e3